### PR TITLE
Remove CIB version in case no --no-version.

### DIFF
--- a/modules/cibconfig.py
+++ b/modules/cibconfig.py
@@ -2372,7 +2372,6 @@ class CibFactory(object):
         self._set_cib_attributes(self.cib_orig)
         current_cib = None  # don't need that anymore
         # only bump epoch if we don't have support for --no-version
-        # TODO: strip version information before generating patch
         if not self._crm_diff_cmd.endswith('--no-version'):
             # now increase the epoch by 1
             self.bump_epoch()
@@ -2393,6 +2392,9 @@ class CibFactory(object):
         if not cib_diff:
             common_err("crm_diff apparently failed to produce the diff (rc=%d)" % rc)
             return False
+        if not self._crm_diff_cmd.endswith('--no-version'):
+            # if we dont have support for --no-version skip the version information for source and target
+            cib_diff = re.sub(r'<(target|source).*', r'<\1/>', cib_diff);
         common_debug("Diff: %s" % (cib_diff))
         rc = pipe_string("%s %s" % (cib_piped, cibadmin_opts),
                          cib_diff)


### PR DESCRIPTION
In case of switch --no-version of crm_diff not available, skip the version information in cib diff.
Skipping the epoch and num_updates information in source and target has the same result as completely skipping the version section in generated diff.